### PR TITLE
Need later version of ffi to work with more modern versions of Node.js

### DIFF
--- a/rsgex/package.json
+++ b/rsgex/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/steveklabnik/forward2015#readme",
   "dependencies": {
-    "ffi": "^1.3.1",
+    "ffi": "^2.0.0",
     "ref": "^1.0.2"
   }
 }


### PR DESCRIPTION
Hi Steve

you need to use ffi>2.0.0 for your project to build out of the box with the latest Node disteribution (well, at least 5.5.0).

Hope this helps
